### PR TITLE
Updating Databricks Agent Example

### DIFF
--- a/examples/databricks_agent/databricks_agent/databricks_agent_example_usage.py
+++ b/examples/databricks_agent/databricks_agent/databricks_agent_example_usage.py
@@ -21,6 +21,7 @@ from flytekitplugins.spark import DatabricksV2 as Databricks
 # %%
 @task(
     task_config=Databricks(
+        databricks_instance="databricks.example.com"
         spark_conf={
             "spark.driver.memory": "1000M",
             "spark.executor.memory": "1000M",


### PR DESCRIPTION
Added `databricks_instance` into the `task_config`, which the agent requires. Discussed  in the following Slack [databricks_instance](https://flyte-org.slack.com/archives/CP2HDHKE1/p1737138370681959)